### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/josephhodges/f5941582-3fe8-4b73-910c-44c3631c8772/8df02d0b-2372-4427-a653-fd84f73b4962/_apis/work/boardbadge/c36ecc8e-86c9-4d33-b185-5f2863ffd14c)](https://dev.azure.com/josephhodges/f5941582-3fe8-4b73-910c-44c3631c8772/_boards/board/t/8df02d0b-2372-4427-a653-fd84f73b4962/Microsoft.RequirementCategory)
 # ecoservice [![Build Status](https://travis-ci.org/OpenTreeMap/otm-ecoservice.svg?branch=master)](https://travis-ci.org/OpenTreeMap/otm-ecoservice)
 
 REST services for calculating eco benefits for trees in an [OpenTreeMap](https://github.com/OpenTreeMap) database.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/josephhodges/f5941582-3fe8-4b73-910c-44c3631c8772/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.